### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/apis/ui/v1alpha1/register.go
+++ b/apis/ui/v1alpha1/register.go
@@ -53,7 +53,8 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&Dbgate{},
 		&DbgateList{},
 		&MongoUi{},
@@ -64,7 +65,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&PhpmyadminList{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/apis/ui/v1alpha1/types_test.go
+++ b/apis/ui/v1alpha1/types_test.go
@@ -26,7 +26,8 @@ import (
 )
 
 func TestDefaultValues(t *testing.T) {
-	checker := schemachecker.New(os.DirFS("../../.."),
+	checker := schemachecker.New(
+		os.DirFS("../../.."),
 		schemachecker.TestCase{Obj: v1alpha1.DbgateSpec{}},
 		schemachecker.TestCase{Obj: v1alpha1.MongoUiSpec{}},
 		schemachecker.TestCase{Obj: v1alpha1.PgadminSpec{}},


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
